### PR TITLE
Fix not permitted characters in file name

### DIFF
--- a/scraper.js
+++ b/scraper.js
@@ -270,7 +270,7 @@ var scrapContentToFile = function(params, callback) {
                     }
                 });
             });
-            fs.writeFile(config.saveDirectory + '/' + data.name + '.json', JSON.stringify(data, null, 2));
+            fs.writeFile(config.saveDirectory + '/' + data.name.replace(/[\/\\\?\*\|:"<>]/, '_') + '.json', JSON.stringify(data, null, 2));
             callback(null, []);
         } else {
             callback(error);


### PR DESCRIPTION
If some model include special characters in the name it's impossible to create such file for scraped data.
Ex.: [Mitsubishi M341i/M720](http://www.gsmarena.com/mitsubishi_m341i_m720-593.php) and [NEC e540/N411i](http://www.gsmarena.com/nec_e540_n411i-1094.php) include slashes in their names.
List of not permitted characters(Windows): https://msdn.microsoft.com/en-us/library/c6bdca6y(v=vs.90).aspx